### PR TITLE
Allow for IDs to contain `:` characters

### DIFF
--- a/src/node/node.js
+++ b/src/node/node.js
@@ -93,10 +93,11 @@ export function toGlobalId(type: string, id: string): string {
  * used to create it.
  */
 export function fromGlobalId(globalId: string): ResolvedGlobalId {
-  var tokens = unbase64(globalId).split(':', 2);
+  var unbasedGlobalId = unbase64(globalId);
+  var delimiterPos = unbasedGlobalId.indexOf(':');
   return {
-    type: tokens[0],
-    id: tokens[1]
+    type: unbasedGlobalId.substring(0, delimiterPos),
+    id: unbasedGlobalId.substring(delimiterPos + 1)
   };
 }
 


### PR DESCRIPTION
I was recently building a toy project with Relay and GraphQL where I
needed to encode extra information in my global ID. To do this, I
decided to add an `idFetcher` argument to my `globalIdField` call that
returned a string that was delimited by a `:`. However, this did not
work because of how globalIds are deconstructed in `fromGlobalId`, so
instead of getting my encoded ID (e.g. `123:test`) I just got the ID
part (e.g. `123`).

To prevent this confusion, it might be nice to either warn when this
happens or use a different strategy in `fromGlobalId` than `split`. In
this commit, I swap out the `split` for a performant
`indexOf`/`substring` approach that satisfies this use-case. Of course,
a regex version would also work here:

```js
  export function fromGlobalId(globalId: string): ResolvedGlobalId {
    var tokens = unbase64(globalId).match(/(.+?):(.+)/);
    return {
      type: tokens[1],
      id: tokens[2]
    };
  }
```

Fixes #18