### PR TITLE
Expose `offsetToCursor` method

### DIFF
--- a/src/connection/arrayconnection.js
+++ b/src/connection/arrayconnection.js
@@ -142,7 +142,7 @@ var PREFIX = 'arrayconnection:';
 /**
  * Creates the cursor string from an offset.
  */
-function offsetToCursor(offset: number): ConnectionCursor {
+export function offsetToCursor(offset: number): ConnectionCursor {
   return base64(PREFIX + offset);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export {
   cursorForObjectInConnection,
   cursorToOffset,
   getOffsetWithDefault,
+  offsetToCursor,
 } from './connection/arrayconnection.js';
 
 // Helper for creating mutations with client mutation IDs


### PR DESCRIPTION
We already export a `cursorForObjectInConnection` method which itself calls `offsetToCursor`, but because it relies internally on `Array.prototype.indexOf` to derive the offset, it is not well suited for use cases where objects may be equivalent but not strictly equal (`===`).

By exporting `offsetToCursor`, schema authors can derive cursors on their own without having to go through `cursorForObjectInConnection`. This mirrors what we do with `cursorToOffset`, which is already exported.

Fixes: https://github.com/graphql/graphql-relay-js/issues/29