### PR TITLE
Extract typo fix from #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,4 @@ npm run watch
 in a terminal. This will watch the file system run lint, tests, and type
 checking automatically whenever you save a js file.
 
-To lint the JS files and type interface checks run `npm run lint`.
+To lint the JS files and run type interface checks run `npm run lint`.


### PR DESCRIPTION
This was fixed in #24, but that one has gone stale and needs updating so
I am clearing it out and pushing this up as the subset of that commit
which still applies and is useful.