### PR TITLE
Testing for too many should test last: 4, not last: 3

### DIFF
--- a/src/connection/__tests__/arrayconnection.js
+++ b/src/connection/__tests__/arrayconnection.js
@@ -406,7 +406,7 @@ describe('connectionFromArray()', () => {
       var c = connectionFromArray(
         letters,
         {
-          last: 3,
+          last: 4,
           after: 'YXJyYXljb25uZWN0aW9uOjA=',
           before: 'YXJyYXljb25uZWN0aW9uOjQ='
         }


### PR DESCRIPTION
Pretty self explanatory, testing for `last: 3` is the same as the `exactly right` test underneath it.