### PR TITLE
Export `pluralIdentifyingRootField` function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,8 @@ export {
 
 // Helper for creating plural identifying root fields
 export {
-  pluralIdentifyingRootField
-} from './node/plural.js'
+  pluralIdentifyingRootField,
+} from './node/plural.js';
 
 // Utilities for creating global IDs in systems that don't have them.
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,11 @@ export {
   nodeDefinitions,
 } from './node/node.js';
 
+// Helper for creating plural identifying root fields
+export {
+  pluralIdentifyingRootField
+} from './node/plural.js'
+
 // Utilities for creating global IDs in systems that don't have them.
 export {
   fromGlobalId,


### PR DESCRIPTION
It seems that the `pluralIdentifyingRootField` function, while documented, is never exported from the `graphql-relay-js` package. This PR adds it to the list of exports.