### PR TITLE
Pass resolve info to pluralIdentifyingRootField's resolveSingleInput

### DIFF
--- a/src/node/__tests__/plural.js
+++ b/src/node/__tests__/plural.js
@@ -42,9 +42,9 @@ var queryType = new GraphQLObjectType({
       description: 'Map from a username to the user',
       inputType: GraphQLString,
       outputType: userType,
-      resolveSingleInput: (username) => ({
+      resolveSingleInput: (username, {rootValue: {lang}}) => ({
         username: username,
-        url: 'www.facebook.com/' + username
+        url: 'www.facebook.com/' + username + '?lang=' + lang
       })
     })
   })
@@ -53,6 +53,8 @@ var queryType = new GraphQLObjectType({
 var schema = new GraphQLSchema({
   query: queryType
 });
+
+var rootVal = {lang: 'en'};
 
 describe('pluralIdentifyingRootField()', () => {
   it('allows fetching', () => {
@@ -66,20 +68,20 @@ describe('pluralIdentifyingRootField()', () => {
       usernames: [
         {
           username: 'dschafer',
-          url: 'www.facebook.com/dschafer'
+          url: 'www.facebook.com/dschafer?lang=en'
         },
         {
           username: 'leebyron',
-          url: 'www.facebook.com/leebyron'
+          url: 'www.facebook.com/leebyron?lang=en'
         },
         {
           username: 'schrockn',
-          url: 'www.facebook.com/schrockn'
+          url: 'www.facebook.com/schrockn?lang=en'
         },
       ]
     };
 
-    return expect(graphql(schema, query)).to.become({data: expected});
+    return expect(graphql(schema, query, rootVal)).to.become({data: expected});
   });
 
   it('correctly introspects', () => {

--- a/src/node/plural.js
+++ b/src/node/plural.js
@@ -17,13 +17,14 @@ import type {
   GraphQLFieldConfig,
   GraphQLInputType,
   GraphQLOutputType,
+  GraphQLResolveInfo
 } from 'graphql';
 
 type PluralIdentifyingRootFieldConfig = {
   argName: string,
   inputType: GraphQLInputType,
   outputType: GraphQLOutputType,
-  resolveSingleInput: (input: any) => ?any,
+  resolveSingleInput: (input: any, info: GraphQLResolveInfo) => ?any,
   description?: ?string,
 };
 
@@ -44,10 +45,10 @@ export function pluralIdentifyingRootField(
     description: config.description,
     type: new GraphQLList(config.outputType),
     args: inputArgs,
-    resolve: (obj, args) => {
+    resolve: (obj, args, info) => {
       var inputs = args[config.argName];
       return Promise.all(inputs.map(
-        input => Promise.resolve(config.resolveSingleInput(input))
+        input => Promise.resolve(config.resolveSingleInput(input, info))
       ));
     }
   };


### PR DESCRIPTION
Updated `pluralIdentifyingRootField` to pass the resolve info object through to the provided `resolveSingleInput`, so that `rootValue` fields (access tokens, etc.) can be utilized while resolving values. The unit test is also updated to exercise resolve info pass-through.