### PR TITLE
added `offsetToCursor` to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ it takes a promise that resolves to an array, and returns a promise that
 resolves to the expected shape by `connectionType`.
  - `cursorForObjectInConnection` is a helper method that takes an array and a
 member object, and returns a cursor for use in the mutation payload.
+- `offsetToCursor` takes the index of a member object in an array and
+returns a cursor for use in the mutation payload.
 
 An example usage of these methods from the [test schema](src/__tests__/starWarsSchema.js):
 


### PR DESCRIPTION
#37 exposed the `offsetToCursor` method to fix what seems to be a pretty common use-case.

It took some digging to find #29 which had the information I needed. I thought it would be helpful to have it documented in the README.