### PR TITLE
Fix connection edges field description

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -116,7 +116,7 @@ export function connectionDefinitions(
       },
       edges: {
         type: new GraphQLList(edgeType),
-        description: 'Information to aid in pagination.'
+        description: 'A list of edges.'
       },
       ...(resolveMaybeThunk(connectionFields): any)
     }),


### PR DESCRIPTION
This appears to be a copy/paste error. 

Not sure what the correct description would be beyond that it is a list of edge typed items.