### PR TITLE
Make compatible with graphql-js v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "babel-runtime": "~5.8.3"
   },
   "peerDependencies": {
-    "graphql": "~0.4.2"
+    "graphql": "~0.5.0"
   },
   "devDependencies": {
     "babel": "5.8.3",
@@ -60,7 +60,7 @@
     "coveralls": "2.11.8",
     "eslint": "2.2.0",
     "flow-bin": "0.22.1",
-    "graphql": "0.4.18",
+    "graphql": "0.5.0",
     "isparta": "3.0.3",
     "mocha": "2.2.5",
     "sane": "1.1.3"

--- a/src/__tests__/starWarsMutationTests.js
+++ b/src/__tests__/starWarsMutationTests.js
@@ -50,7 +50,7 @@ describe('Star Wars mutations', () => {
         clientMutationId: 'abcde',
       }
     };
-    var result = await graphql(StarWarsSchema, mutation, null, params);
+    var result = await graphql(StarWarsSchema, mutation, null, null, params);
     expect(result).to.deep.equal({ data: expected });
   });
 });

--- a/src/node/__tests__/global.js
+++ b/src/node/__tests__/global.js
@@ -130,7 +130,8 @@ var queryType = new GraphQLObjectType({
 });
 
 var schema = new GraphQLSchema({
-  query: queryType
+  query: queryType,
+  types: [userType, photoType, postType]
 });
 
 describe('global ID fields', () => {

--- a/src/node/__tests__/node.js
+++ b/src/node/__tests__/node.js
@@ -48,7 +48,7 @@ var photoData = {
 };
 
 var {nodeField, nodeInterface} = nodeDefinitions(
-  (id, info) => {
+  (id, context, info) => {
     expect(info.schema).to.equal(schema);
     if (userData[id]) {
       return userData[id];
@@ -99,7 +99,8 @@ var queryType = new GraphQLObjectType({
 });
 
 var schema = new GraphQLSchema({
-  query: queryType
+  query: queryType,
+  types: [userType, photoType]
 });
 
 describe('Node interface and fields', () => {

--- a/src/node/__tests__/nodeasync.js
+++ b/src/node/__tests__/nodeasync.js
@@ -64,7 +64,8 @@ var queryType = new GraphQLObjectType({
 });
 
 var schema = new GraphQLSchema({
-  query: queryType
+  query: queryType,
+  types: [userType]
 });
 
 describe('Node interface and fields with async object fetcher', () => {

--- a/src/node/__tests__/plural.js
+++ b/src/node/__tests__/plural.js
@@ -42,7 +42,7 @@ var queryType = new GraphQLObjectType({
       description: 'Map from a username to the user',
       inputType: GraphQLString,
       outputType: userType,
-      resolveSingleInput: (username, {rootValue: {lang}}) => ({
+      resolveSingleInput: (username, context, {rootValue: {lang}}) => ({
         username: username,
         url: 'www.facebook.com/' + username + '?lang=' + lang
       })

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -44,7 +44,7 @@ type typeResolverFn = (object: any) => ?GraphQLObjectType |
  * interface without a provided `resolveType` method.
  */
 export function nodeDefinitions(
-  idFetcher: ((id: string, info: GraphQLResolveInfo) => any),
+  idFetcher: ((id: string, context: any, info: GraphQLResolveInfo) => any),
   typeResolver?: ?typeResolverFn
 ): GraphQLNodeDefinitions {
   var nodeInterface = new GraphQLInterfaceType({
@@ -69,7 +69,7 @@ export function nodeDefinitions(
         description: 'The ID of an object'
       }
     },
-    resolve: (obj, {id}, info) => idFetcher(id, info)
+    resolve: (obj, {id}, context, info) => idFetcher(id, context, info),
   };
 
   return {nodeInterface, nodeField};
@@ -109,15 +109,15 @@ export function fromGlobalId(globalId: string): ResolvedGlobalId {
  */
 export function globalIdField(
   typeName?: ?string,
-  idFetcher?: (object: any, info: GraphQLResolveInfo) => string
+  idFetcher?: (object: any, context: any, info: GraphQLResolveInfo) => string
 ): GraphQLFieldConfig {
   return {
     name: 'id',
     description: 'The ID of an object',
     type: new GraphQLNonNull(GraphQLID),
-    resolve: (obj, args, info) => toGlobalId(
+    resolve: (obj, args, context, info) => toGlobalId(
       typeName || info.parentType.name,
-      idFetcher ? idFetcher(obj, info) : obj.id
+      idFetcher ? idFetcher(obj, context, info) : obj.id
     )
   };
 }

--- a/src/node/plural.js
+++ b/src/node/plural.js
@@ -24,7 +24,8 @@ type PluralIdentifyingRootFieldConfig = {
   argName: string,
   inputType: GraphQLInputType,
   outputType: GraphQLOutputType,
-  resolveSingleInput: (input: any, info: GraphQLResolveInfo) => ?any,
+  resolveSingleInput:
+    (input: any, context: any, info: GraphQLResolveInfo) => ?any,
   description?: ?string,
 };
 
@@ -45,10 +46,12 @@ export function pluralIdentifyingRootField(
     description: config.description,
     type: new GraphQLList(config.outputType),
     args: inputArgs,
-    resolve: (obj, args, info) => {
+    resolve: (obj, args, context, info) => {
       var inputs = args[config.argName];
       return Promise.all(inputs.map(
-        input => Promise.resolve(config.resolveSingleInput(input, info))
+        input => Promise.resolve(
+          config.resolveSingleInput(input, context, info)
+        )
       ));
     }
   };


### PR DESCRIPTION
The third argument to the `resolve` functions is now a `context`, and what was formerly the third argument (the info containing `rootValue` and so on) is now the fourth argument.

See:

https://github.com/graphql/graphql-js/releases/tag/v0.5.0

Also squashes in additional test fixes (additional `types` declarations) from @taion:

https://github.com/graphql/graphql-relay-js/commit/73c5c3fefb9f7ec5ee963f54efab73ae1068fb20

These are required as noted in the v0.5.0 release notes.

> Types can now be explicitly provided to new `GraphQLSchema({ types: [...] })`. Types which implement an interface but are otherwise not referenced as a field return type are no longer automatically added to the Schema!