### PR TITLE
added context param to mutation resolve

### DIFF
--- a/src/mutation/__tests__/mutation.js
+++ b/src/mutation/__tests__/mutation.js
@@ -57,12 +57,24 @@ var simplePromiseMutation = mutationWithClientMutationId({
   mutateAndGetPayload: () => Promise.resolve({result: 1})
 });
 
+var simpleRootValueMutation = mutationWithClientMutationId({
+  name: 'SimpleRootValueMutation',
+  inputFields: {},
+  outputFields: {
+    result: {
+      type: GraphQLInt
+    }
+  },
+  mutateAndGetPayload: (params, context, {rootValue}) => (rootValue)
+});
+
 var mutation = new GraphQLObjectType({
   name: 'Mutation',
   fields: {
     simpleMutation: simpleMutation,
     simpleMutationWithThunkFields: simpleMutationWithThunkFields,
-    simplePromiseMutation: simplePromiseMutation
+    simplePromiseMutation: simplePromiseMutation,
+    simpleRootValueMutation: simpleRootValueMutation
   }
 });
 
@@ -143,6 +155,26 @@ describe('mutationWithClientMutationId()', () => {
       }
     };
     return expect(graphql(schema, query)).to.become(expected);
+  });
+
+  it('can access rootValue', () => {
+    var query = `
+      mutation M {
+        simpleRootValueMutation(input: {clientMutationId: "abc"}) {
+          result
+          clientMutationId
+        }
+      }
+    `;
+    var expected = {
+      data: {
+        simpleRootValueMutation: {
+          result: 1,
+          clientMutationId: 'abc'
+        }
+      }
+    };
+    return expect(graphql(schema, query, {result: 1})).to.become(expected);
   });
 
   describe('introspection', () => {
@@ -322,6 +354,26 @@ describe('mutationWithClientMutationId()', () => {
                 ],
                 type: {
                   name: 'SimplePromiseMutationPayload',
+                  kind: 'OBJECT',
+                }
+              },
+              {
+                name: 'simpleRootValueMutation',
+                args: [
+                  {
+                    name: 'input',
+                    type: {
+                      name: null,
+                      kind: 'NON_NULL',
+                      ofType: {
+                        name: 'SimpleRootValueMutationInput',
+                        kind: 'INPUT_OBJECT'
+                      }
+                    },
+                  }
+                ],
+                type: {
+                  name: 'SimpleRootValueMutationPayload',
                   kind: 'OBJECT',
                 }
               },

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -86,11 +86,12 @@ export function mutationWithClientMutationId(
     args: {
       input: {type: new GraphQLNonNull(inputType)}
     },
-    resolve: (_, {input}, info) => {
-      return Promise.resolve(mutateAndGetPayload(input, info)).then(payload => {
-        payload.clientMutationId = input.clientMutationId;
-        return payload;
-      });
+    resolve: (_, {input}, context, info) => {
+      return Promise.resolve(mutateAndGetPayload(input, context, info))
+        .then(payload => {
+          payload.clientMutationId = input.clientMutationId;
+          return payload;
+        });
     }
   };
 }

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -22,8 +22,9 @@ import type {
   GraphQLResolveInfo
 } from 'graphql';
 
-type mutationFn = (object: Object, info: GraphQLResolveInfo) => Object |
-                  (object: Object, info: GraphQLResolveInfo) => Promise<Object>;
+type mutationFn =
+  (object: Object, ctx: Object, info: GraphQLResolveInfo) => Object |
+  (object: Object, ctx: Object, info: GraphQLResolveInfo) => Promise<Object>;
 
 function resolveMaybeThunk<T>(thingOrThunk: T | () => T): T {
   return typeof thingOrThunk === 'function' ? thingOrThunk() : thingOrThunk;


### PR DESCRIPTION
This is a fix for graphql@0.5.0 which changed the params passed to resolve.