### PR TITLE
Remove non-null restriction on clientMutationId field definitions.

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -101,13 +101,13 @@ import {
  * }
  *
  * input IntroduceShipInput {
- *   clientMutationId: string!
+ *   clientMutationId: string
  *   shipName: string!
  *   factionId: ID!
  * }
  *
- * input IntroduceShipPayload {
- *   clientMutationId: string!
+ * type IntroduceShipPayload {
+ *   clientMutationId: string
  *   ship: Ship
  *   faction: Faction
  * }
@@ -244,13 +244,13 @@ var queryType = new GraphQLObjectType({
  *
  * It creates these two types implicitly:
  *   input IntroduceShipInput {
- *     clientMutationId: string!
+ *     clientMutationId: string
  *     shipName: string!
  *     factionId: ID!
  *   }
  *
- *   input IntroduceShipPayload {
- *     clientMutationId: string!
+ *   type IntroduceShipPayload {
+ *     clientMutationId: string
  *     ship: Ship
  *     faction: Faction
  *   }

--- a/src/mutation/__tests__/mutation.js
+++ b/src/mutation/__tests__/mutation.js
@@ -188,10 +188,6 @@ describe('mutationWithClientMutationId()', () => {
             type {
               name
               kind
-              ofType {
-                name
-                kind
-              }
             }
           }
         }
@@ -204,12 +200,8 @@ describe('mutationWithClientMutationId()', () => {
             {
               name: 'clientMutationId',
               type: {
-                name: null,
-                kind: 'NON_NULL',
-                ofType: {
-                  name: 'String',
-                  kind: 'SCALAR'
-                }
+                name: 'String',
+                kind: 'SCALAR'
               }
             }
           ]
@@ -229,10 +221,6 @@ describe('mutationWithClientMutationId()', () => {
             type {
               name
               kind
-              ofType {
-                name
-                kind
-              }
             }
           }
         }
@@ -247,18 +235,13 @@ describe('mutationWithClientMutationId()', () => {
               type: {
                 name: 'Int',
                 kind: 'SCALAR',
-                ofType: null
               }
             },
             {
               name: 'clientMutationId',
               type: {
-                name: null,
-                kind: 'NON_NULL',
-                ofType: {
-                  name: 'String',
-                  kind: 'SCALAR'
-                }
+                name: 'String',
+                kind: 'SCALAR'
               }
             }
           ]

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -62,13 +62,13 @@ export function mutationWithClientMutationId(
   var augmentedInputFields = () => ({
     ...resolveMaybeThunk(inputFields),
     clientMutationId: {
-      type: new GraphQLNonNull(GraphQLString)
+      type: GraphQLString
     }
   });
   var augmentedOutputFields = () => ({
     ...resolveMaybeThunk(outputFields),
     clientMutationId: {
-      type: new GraphQLNonNull(GraphQLString)
+      type: GraphQLString
     }
   });
 


### PR DESCRIPTION
## Problem

I would like to define a relay compatible graphql server without imposing needless restrictions on the schema like requiring clients to send a clientMutationId in requests and ask for a clientMutationId field in the mutation payload.

graphql-relay-js defines these fields as non-null, but [Relay Input Object Mutations Specification](https://facebook.github.io/relay/graphql/mutations.htm) only says that they *may* be non-null.

I would also like to remove the need to even have the clientMutationId as part of the relay spec entirely, since there is no reason why the client should need to send it over the network, as shown in https://github.com/facebook/relay/pull/1083.  However, making that transition on the relay client would require the server to first make the clientMutationId field nullable so the client can stop sending it.

## Solution

Remove the non-null constraint on clientMutationId in the mutation input object type and payload object type.