### PR TITLE
fix some conflict-types with Graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "coveralls": "2.11.9",
     "eslint": "2.10.2",
     "flow-bin": "0.25.0",
+    "flow-dynamic": "^0.0.9",
+    "flow-graphql": "^0.6.4",
     "graphql": "0.6.0",
     "isparta": "4.0.0",
     "mocha": "2.5.3",

--- a/src/mutation/__tests__/mutation.js
+++ b/src/mutation/__tests__/mutation.js
@@ -92,7 +92,7 @@ describe('mutationWithClientMutationId()', () => {
         }
       }
     `;
-    var result = await graphql(schema, query);
+    var result:any = await graphql(schema, query);
     expect(result.errors.length).to.equal(1);
     expect(result.errors[0].message).to.equal('Field \"simpleMutation\" argument \"input\" of type \"SimpleMutationInput!\" is required but not provided.');
   });

--- a/src/mutation/__tests__/mutation.js
+++ b/src/mutation/__tests__/mutation.js
@@ -65,7 +65,8 @@ var simpleRootValueMutation = mutationWithClientMutationId({
       type: GraphQLInt
     }
   },
-  mutateAndGetPayload: (params, context, {rootValue}) => (rootValue)
+  // :any to ignore type check in test.
+  mutateAndGetPayload: (params, context, {rootValue}) => ((rootValue:any))
 });
 
 var mutation = new GraphQLObjectType({

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -22,9 +22,8 @@ import type {
   GraphQLResolveInfo
 } from 'graphql';
 
-type mutationFn =
-  (object: Object, ctx: Object, info: GraphQLResolveInfo) => Object |
-  (object: Object, ctx: Object, info: GraphQLResolveInfo) => Promise<Object>;
+type mutationFn = (object: Object, ctx: mixed, info: GraphQLResolveInfo) =>
+  ( Object | Promise<Object> );
 
 function resolveMaybeThunk<T>(thingOrThunk: T | () => T): T {
   return typeof thingOrThunk === 'function' ? thingOrThunk() : thingOrThunk;

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -22,6 +22,12 @@ import type {
   GraphQLResolveInfo
 } from 'graphql';
 
+import {
+  graph,
+  pro
+} from 'flow-dynamic';
+const {argsCheck} = graph;
+
 type mutationFn = (object: Object, ctx: mixed, info: GraphQLResolveInfo) =>
   ( Object | Promise<Object> );
 
@@ -86,12 +92,16 @@ export function mutationWithClientMutationId(
     args: {
       input: {type: new GraphQLNonNull(inputType)}
     },
-    resolve: (_, {input}, context, info) => {
-      return Promise.resolve(mutateAndGetPayload(input, context, info))
-        .then(payload => {
-          payload.clientMutationId = input.clientMutationId;
-          return payload;
-        });
-    }
+    resolve: argsCheck(
+      args => ({
+        input: pro.isObject(args.input)
+      }),
+      (_, {input}, context, info) => {
+        return Promise.resolve(mutateAndGetPayload(input, context, info))
+          .then(payload => {
+            payload.clientMutationId = input.clientMutationId;
+            return payload;
+          });
+      })
   };
 }

--- a/src/node/__tests__/plural.js
+++ b/src/node/__tests__/plural.js
@@ -48,10 +48,11 @@ var queryType = new GraphQLObjectType({
       description: 'Map from a username to the user',
       inputType: GraphQLString,
       outputType: userType,
-      // $FlowFixMe : rootValue Graphql(mixed) -> relay(object)
-      resolveSingleInput: (username, context, {rootValue: {lang}}) => ({
+      // rootValue Graphql(mixed) -> relay(object)
+      // :any to ignore type check in test.
+      resolveSingleInput: (username, context, {rootValue}) => ({
         username: username,
-        url: 'www.facebook.com/' + username + '?lang=' + lang
+        url: 'www.facebook.com/' + username + '?lang=' + (rootValue:any).lang
       })
     })
   })

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -30,8 +30,7 @@ type GraphQLNodeDefinitions = {
   nodeField: GraphQLFieldConfig
 }
 
-type typeResolverFn = (object: any) => ?GraphQLObjectType |
-                      (object: any) => ?Promise<GraphQLObjectType>;
+type typeResolverFn = (object: any) => ?GraphQLObjectType;
 
 /**
  * Given a function to map from an ID to an underlying object, and a function
@@ -45,7 +44,7 @@ type typeResolverFn = (object: any) => ?GraphQLObjectType |
  */
 export function nodeDefinitions(
   idFetcher: ((id: string, context: any, info: GraphQLResolveInfo) => any),
-  typeResolver?: ?typeResolverFn
+  typeResolver?: typeResolverFn
 ): GraphQLNodeDefinitions {
   var nodeInterface = new GraphQLInterfaceType({
     name: 'Node',

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -25,6 +25,12 @@ import {
   unbase64
 } from '../utils/base64.js';
 
+import {
+  graph,
+  pro
+} from 'flow-dynamic';
+const {argsCheck, sourceCheck} = graph;
+
 type GraphQLNodeDefinitions = {
   nodeInterface: GraphQLInterfaceType,
   nodeField: GraphQLFieldConfig
@@ -58,6 +64,8 @@ export function nodeDefinitions(
     resolveType: typeResolver
   });
 
+
+
   var nodeField = {
     name: 'node',
     description: 'Fetches an object given its ID',
@@ -68,7 +76,11 @@ export function nodeDefinitions(
         description: 'The ID of an object'
       }
     },
-    resolve: (obj, {id}, context, info) => idFetcher(id, context, info),
+    //  type NodeArgs = {id:string};
+    resolve: argsCheck(
+      args => ({id: pro.isString(args.id) }),
+      (obj, args, context, info) => idFetcher(args.id, context, info)
+    )
   };
 
   return {nodeInterface, nodeField};
@@ -114,9 +126,12 @@ export function globalIdField(
     name: 'id',
     description: 'The ID of an object',
     type: new GraphQLNonNull(GraphQLID),
-    resolve: (obj, args, context, info) => toGlobalId(
-      typeName || info.parentType.name,
-      idFetcher ? idFetcher(obj, context, info) : obj.id
+    resolve: sourceCheck(
+      obj => pro.isObject(obj),
+      (obj, args, context, info) => toGlobalId(
+        typeName || info.parentType.name,
+        idFetcher ? idFetcher(obj, context, info) : obj.id
+      )
     )
   };
 }

--- a/src/node/plural.js
+++ b/src/node/plural.js
@@ -23,6 +23,12 @@ import type {
   GraphQLInputObjectType
 } from 'graphql';
 
+import {
+  graph,
+  pro
+} from 'flow-dynamic';
+const {argsCheck} = graph;
+
 type PluralIdentifyingRootFieldConfig = {
   argName: string,
   inputType: GraphQLInputType,
@@ -47,14 +53,16 @@ export function pluralIdentifyingRootField(
     description: config.description,
     type: new GraphQLList(config.outputType),
     args: inputArgs,
-    resolve: (obj, args, context, info) => {
-      var inputs = args[config.argName];
-      return Promise.all(inputs.map(
-        input => Promise.resolve(
-          config.resolveSingleInput(input, context, info)
-        )
-      ));
-    }
+    resolve: argsCheck( args => pro.isObject(args),
+      (obj, args, context, info) => {
+        var inputs = args[config.argName];
+        return Promise.all(inputs.map(
+          input => Promise.resolve(
+            config.resolveSingleInput(input, context, info)
+          )
+        ));
+      }
+    )
   };
 }
 

--- a/src/node/plural.js
+++ b/src/node/plural.js
@@ -17,7 +17,10 @@ import type {
   GraphQLFieldConfig,
   GraphQLInputType,
   GraphQLOutputType,
-  GraphQLResolveInfo
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLEnumType,
+  GraphQLInputObjectType
 } from 'graphql';
 
 type PluralIdentifyingRootFieldConfig = {
@@ -36,9 +39,7 @@ export function pluralIdentifyingRootField(
   inputArgs[config.argName] = {
     type: new GraphQLNonNull(
             new GraphQLList(
-              new GraphQLNonNull(
-                config.inputType
-              )
+              nonNull(config.inputType)
             )
           )
   };
@@ -55,4 +56,18 @@ export function pluralIdentifyingRootField(
       ));
     }
   };
+}
+
+type NonNullInputType = GraphQLNonNull<
+    GraphQLScalarType |
+    GraphQLEnumType |
+    GraphQLInputObjectType |
+    GraphQLList<GraphQLInputType> >;
+
+export function nonNull(type:GraphQLInputType):NonNullInputType {
+  if ( type instanceof GraphQLNonNull) {
+    return type;
+  } else {
+    return new GraphQLNonNull(type);
+  }
 }


### PR DESCRIPTION
Checked all conflict flow type between `graphql` and `graphql-relay` with `flow-dynamic`.
See this: [not modified any code inside the origin resolver](https://github.com/graphql/graphql-relay-js/pull/89/commits/94c15ffc261cc73fd77ef64c1f99f9ad2b3c05c4#diff-ca9890ee3978e68ab141ce9e3a0b4232R129). and will have no produce-time load, when confirmed those data usage are by design.
I use a own copy `graphql`(which named `flow-graphql`) for temporary type testing. will delete them later. waiting an offcial typed `graphql` package. 
