### PR TITLE
Use UTF-8 instead of ASCII for base64 conversion

### DIFF
--- a/src/utils/__tests__/base64.js
+++ b/src/utils/__tests__/base64.js
@@ -13,7 +13,7 @@ describe('base64 conversion', () => {
   it('converts from utf-8 to base64', () => {
     return expect(base64(exampleUtf8)).to.equal(exampleBase64);
   });
-  
+
   it('converts from base64 to utf-8', () => {
     return expect(unbase64(exampleBase64)).to.equal(exampleUtf8);
   });

--- a/src/utils/__tests__/base64.js
+++ b/src/utils/__tests__/base64.js
@@ -1,0 +1,20 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import {
+  base64,
+  unbase64
+} from '../base64';
+
+var exampleUtf8 = 'Some examples: ❤😀';
+var exampleBase64 = 'U29tZSBleGFtcGxlczog4p2k8J+YgA==';
+
+describe('base64 conversion', () => {
+  it('converts from utf-8 to base64', () => {
+    return expect(base64(exampleUtf8)).to.equal(exampleBase64);
+  });
+  
+  it('converts from base64 to utf-8', () => {
+    return expect(unbase64(exampleBase64)).to.equal(exampleUtf8);
+  });
+});

--- a/src/utils/base64.js
+++ b/src/utils/base64.js
@@ -11,9 +11,9 @@
 export type Base64String = string;
 
 export function base64(i: string): Base64String {
-  return ((new Buffer(i, 'ascii')).toString('base64'));
+  return ((new Buffer(i, 'utf8')).toString('base64'));
 }
 
 export function unbase64(i: Base64String): string {
-  return ((new Buffer(i, 'base64')).toString('ascii'));
+  return ((new Buffer(i, 'base64')).toString('utf8'));
 }


### PR DESCRIPTION
This PR just changes the coding scheme used for `base64()` and `unbase64()`, so that non-ASCII characters can be used in IDs. This is relevant for example for translation applications ([guigrpa/mady](https://github.com/guigrpa/mady)).

I have also added some tests on `utils.js`.

Related issues: #62, facebook/relay#755.