### PR TITLE
Add `ofType` property to connection and edge types.

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -105,6 +105,7 @@ export function connectionDefinitions(
       ...(resolveMaybeThunk(edgeFields): any)
     }),
   });
+  edgeType.ofType = nodeType;
 
   var connectionType = new GraphQLObjectType({
     name: name + 'Connection',
@@ -121,6 +122,7 @@ export function connectionDefinitions(
       ...(resolveMaybeThunk(connectionFields): any)
     }),
   });
+  connectionType.ofType = nodeType;
 
   return {edgeType, connectionType};
 }


### PR DESCRIPTION
Like `GraphQLNonNull` and `GraphQLList` types, `Connection` type also should have this useful property for getting its internal type. Espessialy via method [`getNamedType`](https://github.com/graphql/graphql-js/blob/master/src/type/definition.js#L180) 

I'll open cross PR to GraphQL about relaxing `getNamedType` method for accepting any object with `ofType` property.
If @leeb found this legal and accept his PR, then you may accept this PR.