### PR TITLE
Fix no-undef lint error in Flow definitions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
   "parser": "babel-eslint",
+  "plugins": [
+    "flowtype"
+  ],
   "arrowFunctions": true,
   "blockBindings": true,
   "classes": true,
@@ -248,6 +251,22 @@
     ],
     "wrap-regex": 0,
     "no-var": 0,
-    "max-len": [2, 80, 4]
+    "max-len": [2, 80, 4],
+    "flowtype/define-flow-type": 2,
+    "flowtype/space-after-type-colon": [
+      1,
+      "always"
+    ],
+    "flowtype/space-before-type-colon": [
+      2,
+      "never"
+    ],
+    "flowtype/use-flow-type": 2,
+    "flowtype/valid-syntax": 2
+  },
+  "settings": {
+    "flowtype": {
+      "onlyFilesWithFlowAnnotation": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "chai-as-promised": "5.3.0",
     "coveralls": "2.11.9",
     "eslint": "2.10.2",
+    "eslint-plugin-flowtype": "^2.11.4",
     "flow-bin": "0.25.0",
     "graphql": "0.6.0",
     "isparta": "4.0.0",


### PR DESCRIPTION
`master` is currently failing lint with no changes:

```
src/connection/arrayconnection.js
   33:15  error  'T' is not defined  no-undef
   35:15  error  'T' is not defined  no-undef
   51:30  error  'T' is not defined  no-undef
   53:23  error  'T' is not defined  no-undef
   67:21  error  'T' is not defined  no-undef
   70:15  error  'T' is not defined  no-undef
  133:30  error  'T' is not defined  no-undef
  136:23  error  'T' is not defined  no-undef
  162:15  error  'T' is not defined  no-undef
  163:11  error  'T' is not defined  no-undef
```

This PR adds `eslint-plugin-flowtype` which is designed to fix this issue and other stylistic rules.