### PR TITLE
Update graphql in devDependencies, use exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "babel-plugin-transform-runtime": "6.9.0",
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-2": "6.5.0",
-    "babel-register": "6.9.0",
     "chai": "3.5.0",
     "chai-as-promised": "5.3.0",
     "coveralls": "2.11.9",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "scripts": {
     "prepublish": "npm test && npm run build",
-    "test": "npm run lint && npm run check && mocha $npm_package_options_mocha",
-    "testonly": "mocha $npm_package_options_mocha",
+    "test": "npm run lint && npm run check && npm run testonly",
+    "testonly": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha",
     "lint": "eslint src",
     "check": "flow check",
     "build": "rm -rf lib/* && babel src --ignore __tests__ --out-dir lib",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,9 @@
     "chai-as-promised": "5.3.0",
     "coveralls": "2.11.9",
     "eslint": "2.10.2",
-    "eslint-plugin-flowtype": "^2.11.4",
+    "eslint-plugin-flowtype": "2.11.4",
     "flow-bin": "0.25.0",
-    "graphql": "0.6.0",
+    "graphql": "0.7.0",
     "isparta": "4.0.0",
     "mocha": "2.5.3",
     "sane": "1.3.4"

--- a/scripts/mocha-bootload.js
+++ b/scripts/mocha-bootload.js
@@ -7,8 +7,6 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-require('babel-register');
-
 var chai = require('chai');
 
 var chaiAsPromised = require('chai-as-promised');


### PR DESCRIPTION
`graphql-js` 0.7.0 was released on 8/25, but there is currently no compatible version of `graphql-relay-js` due to `peerDependencies`. The tests pass fine with 0.7.0, but this will likely fail CI anyway until #100 is merged.