### PR TITLE
array connection: add totalCount to Connection

### DIFF
--- a/src/connection/__tests__/arrayconnection.js
+++ b/src/connection/__tests__/arrayconnection.js
@@ -48,6 +48,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -69,6 +70,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjE=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
@@ -103,6 +105,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -125,6 +128,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -159,6 +163,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -186,6 +191,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -215,6 +221,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -240,6 +247,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
@@ -269,6 +277,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
@@ -298,6 +307,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
@@ -331,6 +341,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -364,6 +375,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -393,6 +405,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -426,6 +439,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -459,6 +473,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -516,6 +531,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -556,6 +572,7 @@ describe('connectionFromArray()', () => {
             cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
           },
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
           endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -573,6 +590,7 @@ describe('connectionFromArray()', () => {
       return expect(c).to.deep.equal({
         edges: [
         ],
+        totalCount: 5,
         pageInfo: {
           startCursor: null,
           endCursor: null,
@@ -624,6 +642,7 @@ describe('connectionFromPromisedArray()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -645,6 +664,7 @@ describe('connectionFromPromisedArray()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjE=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
@@ -681,6 +701,7 @@ describe('connectionFromArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
@@ -713,6 +734,7 @@ describe('connectionFromArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjE=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
@@ -741,6 +763,7 @@ describe('connectionFromArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
@@ -769,6 +792,7 @@ describe('connectionFromArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjI=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
@@ -801,6 +825,7 @@ describe('connectionFromArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjQ=',
@@ -833,6 +858,7 @@ describe('connectionFromArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjI=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -861,6 +887,7 @@ describe('connectionFromArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjM=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjM=',
@@ -892,6 +919,7 @@ describe('connectionFromPromisedArraySlice()', () => {
           cursor: 'YXJyYXljb25uZWN0aW9uOjE=',
         },
       ],
+      totalCount: 5,
       pageInfo: {
         startCursor: 'YXJyYXljb25uZWN0aW9uOjA=',
         endCursor: 'YXJyYXljb25uZWN0aW9uOjE=',

--- a/src/connection/__tests__/connection.js
+++ b/src/connection/__tests__/connection.js
@@ -8,7 +8,6 @@
  */
 
 import {
-  GraphQLInt,
   GraphQLObjectType,
   GraphQLSchema,
   GraphQLString,
@@ -69,12 +68,6 @@ var {connectionType: friendConnection} = connectionDefinitions({
     friendshipTime: {
       type: GraphQLString,
       resolve: () => 'Yesterday'
-    }
-  }),
-  connectionFields: () => ({
-    totalCount: {
-      type: GraphQLInt,
-      resolve: () => allUsers.length - 1
     }
   }),
 });

--- a/src/connection/arrayconnection.js
+++ b/src/connection/arrayconnection.js
@@ -122,6 +122,7 @@ export function connectionFromArraySlice<T>(
   var upperBound = before ? beforeOffset : arrayLength;
   return {
     edges,
+    totalCount: arrayLength,
     pageInfo: {
       startCursor: firstEdge ? firstEdge.cursor : null,
       endCursor: lastEdge ? lastEdge.cursor : null,

--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -110,6 +110,10 @@ export function connectionDefinitions(
     name: name + 'Connection',
     description: 'A connection to a list of items.',
     fields: () => ({
+      totalCount: {
+        type: new GraphQLNonNull(GraphQLInt),
+        description: 'The total number of items in the list.'
+      },
       pageInfo: {
         type: new GraphQLNonNull(pageInfoType),
         description: 'Information to aid in pagination.'

--- a/src/connection/connectiontypes.js
+++ b/src/connection/connectiontypes.js
@@ -29,6 +29,7 @@ export type PageInfo = {
 export type Connection<T> = {
   edges: Array<Edge<T>>;
   pageInfo: PageInfo;
+  totalCount: number;
 }
 
 /**


### PR DESCRIPTION
The totalCount attribute on connection types makes it easy to get the
size of the entire collection and makes it explicit. This is especially
useful for large collections where calculating the total size can be
expensive. It's already passed in through the arguments anyway in meta,
but this makes sure it is exposed in the Connection object returned.

An example query:

```
{
  empire {
    ships {
      totalCount
    }
  }
}
```
