### PR TITLE
Update graphql peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-runtime": "^6.9.0"
   },
   "peerDependencies": {
-    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0"
+    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0"
   },
   "devDependencies": {
     "babel-cli": "6.9.0",
@@ -58,7 +58,7 @@
     "eslint": "2.10.2",
     "eslint-plugin-flowtype": "2.11.4",
     "flow-bin": "0.25.0",
-    "graphql": "0.7.0",
+    "graphql": "0.8.1",
     "isparta": "4.0.0",
     "mocha": "2.5.3",
     "sane": "1.3.4"


### PR DESCRIPTION
I didn't want to touch the other dependencies given the open Greenkeeper PRs, but they should probably be updated as well.