### PR TITLE
allow deprecationReason in mutationWithClientMutationId

### DIFF
--- a/src/mutation/__tests__/mutation.js
+++ b/src/mutation/__tests__/mutation.js
@@ -43,6 +43,18 @@ const simpleMutationWithDescription = mutationWithClientMutationId({
   mutateAndGetPayload: () => ({result: 1})
 });
 
+const simpleMutationWithDeprecationReason = mutationWithClientMutationId({
+  name: 'SimpleMutationWithDeprecationReason',
+  inputFields: {},
+  outputFields: {
+    result: {
+      type: GraphQLInt
+    }
+  },
+  mutateAndGetPayload: () => ({result: 1}),
+  deprecationReason: 'Just because'
+});
+
 const simpleMutationWithThunkFields = mutationWithClientMutationId({
   name: 'SimpleMutationWithThunkFields',
   inputFields: () => ({
@@ -92,6 +104,7 @@ const mutationType = new GraphQLObjectType({
   fields: {
     simpleMutation,
     simpleMutationWithDescription,
+    simpleMutationWithDeprecationReason,
     simpleMutationWithThunkFields,
     simplePromiseMutation,
     simpleRootValueMutation,
@@ -145,7 +158,7 @@ describe('mutationWithClientMutationId()', () => {
     });
   });
 
-  it('Supports thunks as input and output fields', async () => {
+  it('supports thunks as input and output fields', async () => {
     const query = `
       mutation M {
         simpleMutationWithThunkFields(input: {
@@ -458,6 +471,61 @@ describe('mutationWithClientMutationId()', () => {
                 {
                   name: 'simpleRootValueMutation',
                   description: null
+                }
+              ]
+            }
+          }
+        }
+      });
+    });
+
+    it('contains correct deprecation reasons', async () => {
+      const query = `{
+        __schema {
+          mutationType {
+            fields(includeDeprecated: true) {
+              name
+              isDeprecated
+              deprecationReason
+            }
+          }
+        }
+      }`;
+
+      return expect(await graphql(schema, query)).to.deep.equal({
+        data: {
+          __schema: {
+            mutationType: {
+              fields: [
+                {
+                  name: 'simpleMutation',
+                  isDeprecated: false,
+                  deprecationReason: null
+                },
+                {
+                  name: 'simpleMutationWithDescription',
+                  isDeprecated: false,
+                  deprecationReason: null
+                },
+                {
+                  name: 'simpleMutationWithDeprecationReason',
+                  isDeprecated: true,
+                  deprecationReason: 'Just because',
+                },
+                {
+                  name: 'simpleMutationWithThunkFields',
+                  isDeprecated: false,
+                  deprecationReason: null
+                },
+                {
+                  name: 'simplePromiseMutation',
+                  isDeprecated: false,
+                  deprecationReason: null
+                },
+                {
+                  name: 'simpleRootValueMutation',
+                  isDeprecated: false,
+                  deprecationReason: null
                 }
               ]
             }

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -50,6 +50,7 @@ function resolveMaybeThunk<T>(thingOrThunk: Thunk<T>): T {
 type MutationConfig = {
   name: string,
   description?: string,
+  deprecationReason?: string,
   inputFields: Thunk<GraphQLInputFieldConfigMap>,
   outputFields: Thunk<GraphQLFieldConfigMap<*, *>>,
   mutateAndGetPayload: mutationFn,
@@ -65,6 +66,7 @@ export function mutationWithClientMutationId(
   const {
     name,
     description,
+    deprecationReason,
     inputFields,
     outputFields,
     mutateAndGetPayload
@@ -95,6 +97,7 @@ export function mutationWithClientMutationId(
   return {
     type: outputType,
     description,
+    deprecationReason,
     args: {
       input: {type: new GraphQLNonNull(inputType)}
     },


### PR DESCRIPTION
So, we can avoid something like:

```js
const mutationType = new GraphQLObjectType({
  name: 'Mutation',
  fields: {
    simpleMutationWithDeprecationReason: {
      ...simpleMutationWithDeprecationReason,
      deprecationReason: 'Just because',
    },
  },
});
```