### PR TITLE
Add runAfterMutation method to mutateAndGetPayload

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,13 @@ var shipMutation = mutationWithClientMutationId({
       shipId: newShip.id,
       factionId: factionId,
     };
-  }
+  },
+  // Optional method
+  runAfterMutation: (resolvedPayload) => new Promise((resolve) => {
+    // We can now access the resolved ship & faction output type
+    // Do stuff with resolvedPayload...
+    resolve();
+  })
 });
 
 var mutationType = new GraphQLObjectType({

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -117,7 +117,12 @@ export function mutationWithClientMutationId(
         .then(payload => {
           payload.clientMutationId = input.clientMutationId;
           if (runAfterMutation) {
-            return Promise.resolve(runAfterMutation(payload)).then(() => payload);
+            return Promise.resolve(runAfterMutation(payload))
+              .then(() => payload)
+              .catch((err) => {
+                console.log(err, 'Error in runAfterMutation');
+                return payload;
+              });
           }
           return payload;
         });

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -62,7 +62,7 @@ type MutationConfig = {
   inputFields: Thunk<GraphQLInputFieldConfigMap>,
   outputFields: Thunk<GraphQLFieldConfigMap<*, *>>,
   mutateAndGetPayload: mutationFn,
-  runAfterMutation: runAfterMutationFn
+  runAfterMutation?: runAfterMutationFn
 };
 
 /**
@@ -79,7 +79,7 @@ export function mutationWithClientMutationId(
     inputFields,
     outputFields,
     mutateAndGetPayload,
-    runAfterMutation
+    runAfterMutation,
   } = config;
   const augmentedInputFields = () => ({
     ...resolveMaybeThunk(inputFields),
@@ -119,6 +119,11 @@ export function mutationWithClientMutationId(
             return Promise.resolve(runAfterMutation(payload))
               .then(() => payload)
               .catch(err => {
+                /**
+                 * This shouldn't make the mutation fail. However
+                 * we should let the user know about there error
+                 * & then return the payload
+                 */
                 console.log(err, 'Error in runAfterMutation');
                 return payload;
               });

--- a/src/mutation/mutation.js
+++ b/src/mutation/mutation.js
@@ -30,8 +30,7 @@ type mutationFn = (
 ) => Promise<any> | any;
 
 type runAfterMutationFn = (
-  object: any,
-  info: GraphQLResolveInfo
+  object: any
 ) => Promise<any> | any;
 
 function resolveMaybeThunk<T>(thingOrThunk: Thunk<T>): T {
@@ -51,7 +50,7 @@ function resolveMaybeThunk<T>(thingOrThunk: Thunk<T>): T {
  * mutateAndGetPayload will receieve an Object with a key for each
  * input field, and it should return an Object with a key for each
  * output field. It may return synchronously, or return a Promise.
- * 
+ *
  * runAfterMutation will resolve with the payload from the resolved
  * mutateAndGetPayload. Example usage may be to save the payload to
  * an in memory database.
@@ -119,7 +118,7 @@ export function mutationWithClientMutationId(
           if (runAfterMutation) {
             return Promise.resolve(runAfterMutation(payload))
               .then(() => payload)
-              .catch((err) => {
+              .catch(err => {
                 console.log(err, 'Error in runAfterMutation');
                 return payload;
               });


### PR DESCRIPTION
Note: The linter errors will need to be fixed (this can be done once I get confirmation that this feature is something that could be implemented). I will also need to update the example `.js` file.

I was surprised to find out that this method was not already there? There are multiple use cases for this method:

1. Caching - If you want to cache specific payloads
2. Realtime - If you aren't using graphql subscriptions and have built your own custom solution, being able to emit the final payload would be SUPER handy. For instance I had to do a lot of manual work to replicate a graphql payload (manually converting to global ids, fetching database objects which aren't in the current mutation scope but would be in the resolved payload, etc...) 
3. Debugging 
4. If you need to run methods that require access to the mutation payload, you can add them in here.


A simple sample would go as follows:

```
mutateAndGetPayload...,
runAfterMutation: payload => new Promise((resolve) => {
    redis.set('updated_user', payload.user);
    resolve();
})
```

Is this a feature you would consider having?