### PR TITLE
allow connection nodeType to be an interface

### DIFF
--- a/src/connection/connection.js
+++ b/src/connection/connection.js
@@ -11,6 +11,7 @@
 import {
   GraphQLBoolean,
   GraphQLInt,
+  GraphQLInterfaceType,
   GraphQLNonNull,
   GraphQLList,
   GraphQLObjectType,
@@ -61,7 +62,7 @@ export const connectionArgs: GraphQLFieldConfigArgumentMap = {
 
 type ConnectionConfig = {
   name?: ?string,
-  nodeType: GraphQLObjectType,
+  nodeType: GraphQLObjectType | GraphQLInterfaceType,
   resolveNode?: ?GraphQLFieldResolver<*, *>,
   resolveCursor?: ?GraphQLFieldResolver<*, *>,
   edgeFields?: ?Thunk<GraphQLFieldConfigMap<*, *>>,


### PR DESCRIPTION
Assuming that this does not violate the connection spec, allow the `nodeType` to be of type `GraphQLInterfaceType`.

Addresses: https://github.com/graphql/graphql-relay-js/issues/160

I was somewhat confused by the existing connection spec. Would someone please advise regarding testing?

I'm mentioning @leebyron as well, to confirm that this doesn't violate the intent of one of the various GraphQL specs.