### PR TITLE
Fix #173 - Export flow types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export type {
   Edge,
   PageInfo,
 } from './connection/connectiontypes.js';
-  
+
 // Helpers for creating connection types in the schema
 export {
   backwardConnectionArgs,

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,15 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+// Flow types for creating connection types in the schema
+export type {
+  Connection,
+  ConnectionArguments,
+  ConnectionCursor,
+  Edge,
+  PageInfo,
+} from './connection/connectiontypes.js';
+  
 // Helpers for creating connection types in the schema
 export {
   backwardConnectionArgs,


### PR DESCRIPTION
This simply re-exports the connection flow types for creating connection types in the schema.