### PR TITLE
Update flow to 0.57

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint": "^3.14.1",
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-flowtype": "^2.30.0",
-    "flow-bin": "^0.56.0",
+    "flow-bin": "^0.57.0",
     "graphql": "^0.11.7",
     "isparta": "4.0.0",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-flowtype": "^2.30.0",
     "flow-bin": "^0.56.0",
-    "graphql": "0.9.1",
+    "graphql": "^0.11.7",
     "isparta": "4.0.0",
     "mocha": "^3.2.0",
     "sane": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint": "^3.14.1",
     "eslint-plugin-babel": "^4.0.1",
     "eslint-plugin-flowtype": "^2.30.0",
-    "flow-bin": "^0.38.0",
+    "flow-bin": "^0.56.0",
     "graphql": "0.9.1",
     "isparta": "4.0.0",
     "mocha": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,9 +1084,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.38.0.tgz#3ae096d401c969cc8b5798253fb82381e2d0237a"
+flow-bin@^0.56.0:
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.56.0.tgz#ce43092203a344ba9bf63c0cabe95d95145f6cad"
 
 for-in@^0.1.5:
   version "0.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,8 +1085,8 @@ flat-cache@^1.2.1:
     write "^0.2.1"
 
 flow-bin@^0.57.0:
-  version "0.57.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.2.tgz#0b5ed4dd38a1991047e9bee71d62a763ae61b6b7"
+  version "0.57.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
 
 for-in@^0.1.5:
   version "0.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,11 +1248,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql@0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.9.1.tgz#f4d154cbec054d4a5d3b1be95f23435c09aa86c8"
+graphql@^0.11.7:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.11.7.tgz#e5abaa9cb7b7cccb84e9f0836bf4370d268750c6"
   dependencies:
-    iterall "1.0.3"
+    iterall "1.1.3"
 
 growl@1.9.2:
   version "1.9.2"
@@ -1528,9 +1528,9 @@ istanbul@^0.4.0:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-iterall@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.0.3.tgz#e0b31958f835013c323ff0b10943829ac69aa4b7"
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 jodid25519@^1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,8 +1085,8 @@ flat-cache@^1.2.1:
     write "^0.2.1"
 
 flow-bin@^0.57.0:
-  version "0.57.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.1.tgz#2fb37a8b6c9b0426bd3bf1a6158d4a659c2178a2"
+  version "0.57.2"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.2.tgz#0b5ed4dd38a1991047e9bee71d62a763ae61b6b7"
 
 for-in@^0.1.5:
   version "0.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,9 +1084,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.56.0:
-  version "0.56.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.56.0.tgz#ce43092203a344ba9bf63c0cabe95d95145f6cad"
+flow-bin@^0.57.0:
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.1.tgz#2fb37a8b6c9b0426bd3bf1a6158d4a659c2178a2"
 
 for-in@^0.1.5:
   version "0.1.6"


### PR DESCRIPTION
As Flow 0.38 is pretty old now and the GraphQL typedefs have changed, i'd like to suggest to update them to the most recent versions. GraphQL and Flow have been updated in the same PR because Flow 0.56 causes errors with GraphQL 0.9.1.