### PR TITLE
Fix `yarn` cmd. check the length of npm_config_argv in prepublish

### DIFF
--- a/resources/prepublish.sh
+++ b/resources/prepublish.sh
@@ -1,7 +1,7 @@
 # Because of a long-running npm issue (https://github.com/npm/npm/issues/3059)
 # prepublish runs after `npm install` and `npm pack`.
 # In order to only run prepublish before `npm publish`, we have to check argv.
-if node -e "process.exit(($npm_config_argv).original[0].indexOf('pu') === 0)"; then
+if node -e "process.exit(($npm_config_argv).original.length > 0 && ($npm_config_argv).original[0].indexOf('pu') === 0)"; then
   exit 0;
 fi
 


### PR DESCRIPTION
The same fix was already applied to other GraphQL related repo:
https://github.com/graphql/graphql-js/pull/1110
https://github.com/graphql/codemirror-graphql/pull/235/commits/e2d40a7fb9cb7803e8e07f54f069491b60b307e9
https://github.com/graphql/graphiql/commit/a4d9732318a753deec37929cfbfd4a1719507468