### PR TITLE
allowing for multiple node definitions

### DIFF
--- a/src/node/__tests__/node.js
+++ b/src/node/__tests__/node.js
@@ -334,7 +334,7 @@ describe('Node interface and fields', () => {
   describe('introspection', () => {
     it('has correct node interface', async () => {
       const query = `{
-        __type(name: "Node") {
+        __type(name: "Node_Node") {
           name
           kind
           fields {
@@ -353,7 +353,7 @@ describe('Node interface and fields', () => {
       return expect(await graphql(schema, query)).to.deep.equal({
         data: {
           __type: {
-            name: 'Node',
+            name: 'Node_Node',
             kind: 'INTERFACE',
             fields: [
               {
@@ -405,7 +405,7 @@ describe('Node interface and fields', () => {
                 {
                   name: 'node',
                   type: {
-                    name: 'Node',
+                    name: 'Node_Node',
                     kind: 'INTERFACE'
                   },
                   args: [

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -43,10 +43,12 @@ type GraphQLNodeDefinitions = {
  */
 export function nodeDefinitions<TContext>(
   idFetcher: ((id: string, context: TContext, info: GraphQLResolveInfo) => any),
-  typeResolver?: ?GraphQLTypeResolver<*, TContext>
+  typeResolver?: ?GraphQLTypeResolver<*, TContext>,
+  nodeName: string = 'Node'
 ): GraphQLNodeDefinitions {
+
   const nodeInterface = new GraphQLInterfaceType({
-    name: 'Node',
+    name: nodeName,
     description: 'An object with an ID',
     fields: () => ({
       id: {
@@ -58,7 +60,7 @@ export function nodeDefinitions<TContext>(
   });
 
   const nodeField = {
-    name: 'node',
+    name: nodeName.toLowerCase(),
     description: 'Fetches an object given its ID',
     type: nodeInterface,
     args: {
@@ -71,7 +73,7 @@ export function nodeDefinitions<TContext>(
   };
 
   const nodesField = {
-    name: 'nodes',
+    name: nodeName.toLowerCase() + 's',
     description: 'Fetches objects given their IDs',
     type: new GraphQLNonNull(
       new GraphQLList(

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -48,7 +48,7 @@ export function nodeDefinitions<TContext>(
 ): GraphQLNodeDefinitions {
 
   const nodeInterface = new GraphQLInterfaceType({
-    name: nodeName,
+    name: nodeName + '_Node',
     description: 'An object with an ID',
     fields: () => ({
       id: {
@@ -60,7 +60,7 @@ export function nodeDefinitions<TContext>(
   });
 
   const nodeField = {
-    name: nodeName.toLowerCase(),
+    name: nodeName + '_node',
     description: 'Fetches an object given its ID',
     type: nodeInterface,
     args: {
@@ -73,7 +73,7 @@ export function nodeDefinitions<TContext>(
   };
 
   const nodesField = {
-    name: nodeName.toLowerCase() + 's',
+    name: nodeName + '_nodes',
     description: 'Fetches objects given their IDs',
     type: new GraphQLNonNull(
       new GraphQLList(


### PR DESCRIPTION
I understand there may be better ways to going about this, but I didn't want to disturb too much code. At the moment, in order to build these schemas, you're essentially dealing with massive files, especially when it comes to node definitions. Allowing for different node definitions per different node types I think would greatly allow for further decoupling and modularization of unrelated node types.