### PR TITLE
Bumping minor version to update npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-relay",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A library to help construct a graphql-js server supporting react-relay.",
   "contributors": [
     "Daniel Schafer <dschafer@fb.com>"


### PR DESCRIPTION
After the release of `graphql@14.x` the package.json was updated to work with the latest graphql version
```
  "devDependencies": {
    ...
    "graphql": "^14.0.2"
    ...
  }
```
However this wasn't publish to the npm registry, giving a warning when you install the latest version.

Running  `yarn add graphql-relay` shows the following warning:
```
warning " > graphql-relay@0.5.5" has incorrect peer dependency "graphql@^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0".
```

And exploring the `package.json` file within `node_modules/graphql-relay` we can see that it is installing the package with the old version:
```
  "devDependencies": {
    ...
    "graphql": "^0.13.1"
    ...
  }
```

Not sure if this was intentional or can't be published because of the incident with keys removal [https://blog.npmjs.org/post/175824896885/incident-report-npm-inc-operations-incident-of](url)
