### PR TITLE
chore(dependencies): use prettier as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,9 +76,7 @@
     "graphql": "^14.1.1",
     "isparta": "4.1.0",
     "mocha": "^5.2.0",
+    "prettier": "^1.16.0",
     "sane": "^2.5.2"
-  },
-  "dependencies": {
-    "prettier": "^1.16.0"
   }
 }


### PR DESCRIPTION
This is actually breaking my test CI and probably not only mine.

I am not really sure how it ended up there since @kassens' [PR](https://github.com/graphql/graphql-relay-js/pull/222) was adding correctly.
Hope I haven't missed anything important but the test are passing 😄 

would you consider patching the npm version ?