### PR TITLE
Use $ReadOnlyArray type for connection data

### DIFF
--- a/src/connection/arrayconnection.js
+++ b/src/connection/arrayconnection.js
@@ -26,7 +26,7 @@ type ArraySliceMetaInfo = {
  * so pagination will only work if the array is static.
  */
 export function connectionFromArray<T>(
-  data: Array<T>,
+  data: $ReadOnlyArray<T>,
   args: ConnectionArguments
 ): Connection<T> {
   return connectionFromArraySlice(data, args, {
@@ -40,7 +40,7 @@ export function connectionFromArray<T>(
  * promised connection.
  */
 export function connectionFromPromisedArray<T>(
-  dataPromise: Promise<Array<T>>,
+  dataPromise: Promise<$ReadOnlyArray<T>>,
   args: ConnectionArguments
 ): Promise<Connection<T>> {
   return dataPromise.then(data => connectionFromArray(data, args));
@@ -56,7 +56,7 @@ export function connectionFromPromisedArray<T>(
  * total result large enough to cover the range specified in `args`.
  */
 export function connectionFromArraySlice<T>(
-  arraySlice: Array<T>,
+  arraySlice: $ReadOnlyArray<T>,
   args: ConnectionArguments,
   meta: ArraySliceMetaInfo
 ): Connection<T> {
@@ -115,7 +115,7 @@ export function connectionFromArraySlice<T>(
  * and returns a promised connection.
  */
 export function connectionFromPromisedArraySlice<T>(
-  dataPromise: Promise<Array<T>>,
+  dataPromise: Promise<$ReadOnlyArray<T>>,
   args: ConnectionArguments,
   arrayInfo: ArraySliceMetaInfo
 ): Promise<Connection<T>> {
@@ -144,7 +144,7 @@ export function cursorToOffset(cursor: ConnectionCursor): number {
  * Return the cursor associated with an object in an array.
  */
 export function cursorForObjectInConnection<T>(
-  data: Array<T>,
+  data: $ReadOnlyArray<T>,
   object: T
 ): ?ConnectionCursor {
   const offset = data.indexOf(object);


### PR DESCRIPTION
Hi good people 👋 

I would like to suggest to use more strict type for connection data - `$ReadOnlyArray<T>`

**Why?**

We define all our types for data on GraphQL server as read-only, so passing data to `connectionFromArray` fails on flow unless we change the type to normal array or do workaround like `[...children]`:

```
connectionFromArray<Item>(children, args);
// Cannot call `connectionFromArray` with `children` bound to `data` because read-only array type [1] is incompatible with array type [2]
```

With these changes, it should be possible to opt-in for `$ReadOnlyArray<T>` while `Array<T>` would still work as well.