### PR TITLE
Add TypeScript declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "http://github.com/graphql/graphql-relay-js.git"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "prepublish": "./resources/prepublish.sh",
     "prettier": "prettier --write --list-different .",

--- a/src/connection/arrayconnection.d.ts
+++ b/src/connection/arrayconnection.d.ts
@@ -1,0 +1,82 @@
+import type {
+  Connection,
+  ConnectionArguments,
+  ConnectionCursor,
+} from './connectiontypes';
+
+export interface ArraySliceMetaInfo {
+  sliceStart: number;
+  arrayLength: number;
+}
+
+/**
+ * A simple function that accepts an array and connection arguments, and returns
+ * a connection object for use in GraphQL. It uses array offsets as pagination,
+ * so pagination will only work if the array is static.
+ */
+export function connectionFromArray<T>(
+  data: T[],
+  args: ConnectionArguments,
+): Connection<T>;
+
+/**
+ * A version of `connectionFromArray` that takes a promised array, and returns a
+ * promised connection.
+ */
+export function connectionFromPromisedArray<T>(
+  dataPromise: Promise<T[]>,
+  args: ConnectionArguments,
+): Promise<Connection<T>>;
+
+/**
+ * Given a slice (subset) of an array, returns a connection object for use in
+ * GraphQL.
+ *
+ * This function is similar to `connectionFromArray`, but is intended for use
+ * cases where you know the cardinality of the connection, consider it too large
+ * to materialize the entire array, and instead wish pass in a slice of the
+ * total result large enough to cover the range specified in `args`.
+ */
+export function connectionFromArraySlice<T>(
+  arraySlice: T[],
+  args: ConnectionArguments,
+  meta: ArraySliceMetaInfo,
+): Connection<T>;
+
+/**
+ * A version of `connectionFromArraySlice` that takes a promised array slice,
+ * and returns a promised connection.
+ */
+export function connectionFromPromisedArraySlice<T>(
+  dataPromise: Promise<T[]>,
+  args: ConnectionArguments,
+  arrayInfo: ArraySliceMetaInfo,
+): Promise<Connection<T>>;
+
+/**
+ * Creates the cursor string from an offset.
+ */
+export function offsetToCursor(offset: number): ConnectionCursor;
+
+/**
+ * Rederives the offset from the cursor string.
+ */
+export function cursorToOffset(cursor: ConnectionCursor): number;
+
+/**
+ * Return the cursor associated with an object in an array.
+ */
+export function cursorForObjectInConnection<T>(
+  data: T[],
+  object: T,
+): ConnectionCursor;
+
+/**
+ * Given an optional cursor and a default offset, returns the offset
+ * to use; if the cursor contains a valid offset, that will be used,
+ * otherwise it will be the default.
+ */
+export function getOffsetWithDefault(
+  cursor?: ConnectionCursor | null,
+  defaultOffset?: number | null,
+): number;

--- a/src/connection/connection.d.ts
+++ b/src/connection/connection.d.ts
@@ -1,0 +1,81 @@
+import type {
+  GraphQLFieldConfigArgumentMap,
+  GraphQLFieldConfigMap,
+  GraphQLFieldResolver,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  Thunk,
+} from 'graphql';
+
+/**
+ * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * whose return type is a connection type with forward pagination.
+ */
+export interface ForwardConnectionArgs {
+  after: { type: GraphQLScalarType };
+  first: { type: GraphQLScalarType };
+}
+
+/**
+ * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * whose return type is a connection type with forward pagination.
+ */
+export const forwardConnectionArgs: GraphQLFieldConfigArgumentMap &
+  ForwardConnectionArgs;
+
+/**
+ * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * whose return type is a connection type with backward pagination.
+ */
+export interface BackwardConnectionArgs {
+  before: { type: GraphQLScalarType };
+  last: { type: GraphQLScalarType };
+}
+
+/**
+ * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * whose return type is a connection type with backward pagination.
+ */
+export const backwardConnectionArgs: GraphQLFieldConfigArgumentMap &
+  BackwardConnectionArgs;
+
+/**
+ * Returns a GraphQLFieldConfigArgumentMap appropriate to include on a field
+ * whose return type is a connection type with bidirectional pagination.
+ */
+export const connectionArgs: GraphQLFieldConfigArgumentMap &
+  ForwardConnectionArgs &
+  BackwardConnectionArgs;
+
+export type ConnectionConfigNodeTypeNullable =
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType;
+
+export type ConnectionConfigNodeType =
+  | ConnectionConfigNodeTypeNullable
+  | GraphQLNonNull<ConnectionConfigNodeTypeNullable>;
+
+export interface ConnectionConfig {
+  name?: string | null;
+  nodeType: ConnectionConfigNodeType;
+  resolveNode?: GraphQLFieldResolver<any, any> | null;
+  resolveCursor?: GraphQLFieldResolver<any, any> | null;
+  edgeFields?: Thunk<GraphQLFieldConfigMap<any, any>> | null;
+  connectionFields?: Thunk<GraphQLFieldConfigMap<any, any>> | null;
+}
+
+export interface GraphQLConnectionDefinitions {
+  edgeType: GraphQLObjectType;
+  connectionType: GraphQLObjectType;
+}
+
+/**
+ * Returns a GraphQLObjectType for a connection with the given name,
+ * and whose nodes are of the specified type.
+ */
+export function connectionDefinitions(
+  config: ConnectionConfig,
+): GraphQLConnectionDefinitions;

--- a/src/connection/connectiontypes.d.ts
+++ b/src/connection/connectiontypes.d.ts
@@ -1,0 +1,40 @@
+/**
+ * An flow type alias for cursors in this implementation.
+ */
+export type ConnectionCursor = string;
+
+/**
+ * A flow type designed to be exposed as `PageInfo` over GraphQL.
+ */
+export interface PageInfo {
+  startCursor?: ConnectionCursor | null;
+  endCursor?: ConnectionCursor | null;
+  hasPreviousPage?: boolean | null;
+  hasNextPage?: boolean | null;
+}
+
+/**
+ * A flow type designed to be exposed as a `Connection` over GraphQL.
+ */
+export interface Connection<T> {
+  edges: Array<Edge<T>>;
+  pageInfo: PageInfo;
+}
+
+/**
+ * A flow type designed to be exposed as a `Edge` over GraphQL.
+ */
+export interface Edge<T> {
+  node: T;
+  cursor: ConnectionCursor;
+}
+
+/**
+ * A flow type describing the arguments a connection field receives in GraphQL.
+ */
+export interface ConnectionArguments {
+  before?: ConnectionCursor | null;
+  after?: ConnectionCursor | null;
+  first?: number | null;
+  last?: number | null;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,40 @@
+// Flow types for creating connection types in the schema
+export type {
+  Connection,
+  ConnectionArguments,
+  ConnectionCursor,
+  Edge,
+  PageInfo,
+} from './connection/connectiontypes';
+
+// Helpers for creating connection types in the schema
+export {
+  backwardConnectionArgs,
+  connectionArgs,
+  connectionDefinitions,
+  forwardConnectionArgs,
+} from './connection/connection';
+
+// Helpers for creating connections from arrays
+export {
+  connectionFromArray,
+  connectionFromArraySlice,
+  connectionFromPromisedArray,
+  connectionFromPromisedArraySlice,
+  cursorForObjectInConnection,
+  cursorToOffset,
+  getOffsetWithDefault,
+  offsetToCursor,
+} from './connection/arrayconnection';
+
+// Helper for creating mutations with client mutation IDs
+export { mutationWithClientMutationId } from './mutation/mutation';
+
+// Helper for creating node definitions
+export { nodeDefinitions } from './node/node';
+
+// Helper for creating plural identifying root fields
+export { pluralIdentifyingRootField } from './node/plural';
+
+// Utilities for creating global IDs in systems that don't have them.
+export { fromGlobalId, globalIdField, toGlobalId } from './node/node';

--- a/src/mutation/mutation.d.ts
+++ b/src/mutation/mutation.d.ts
@@ -1,0 +1,44 @@
+import type {
+  GraphQLFieldConfig,
+  GraphQLInputFieldConfigMap,
+  GraphQLFieldConfigMap,
+  GraphQLResolveInfo,
+  Thunk,
+} from 'graphql';
+
+export type mutationFn = (
+  object: any,
+  ctx: any,
+  info: GraphQLResolveInfo,
+) => Promise<any> | any;
+
+/**
+ * A description of a mutation consumable by mutationWithClientMutationId
+ * to create a GraphQLFieldConfig for that mutation.
+ *
+ * The inputFields and outputFields should not include `clientMutationId`,
+ * as this will be provided automatically.
+ *
+ * An input object will be created containing the input fields, and an
+ * object will be created containing the output fields.
+ *
+ * mutateAndGetPayload will receive an Object with a key for each
+ * input field, and it should return an Object with a key for each
+ * output field. It may return synchronously, or return a Promise.
+ */
+export interface MutationConfig {
+  name: string;
+  description?: string;
+  inputFields: Thunk<GraphQLInputFieldConfigMap>;
+  outputFields: Thunk<GraphQLFieldConfigMap<any, any>>;
+  mutateAndGetPayload: mutationFn;
+  deprecationReason?: string;
+}
+
+/**
+ * Returns a GraphQLFieldConfig for the mutation described by the
+ * provided MutationConfig.
+ */
+export function mutationWithClientMutationId(
+  config: MutationConfig,
+): GraphQLFieldConfig<any, any>;

--- a/src/node/node.d.ts
+++ b/src/node/node.d.ts
@@ -1,0 +1,54 @@
+import type {
+  GraphQLFieldConfig,
+  GraphQLResolveInfo,
+  GraphQLTypeResolver,
+} from 'graphql';
+
+export interface GraphQLNodeDefinitions {
+  nodeInterface: GraphQLInterfaceType;
+  nodeField: GraphQLFieldConfig<any, any>;
+  nodesField: GraphQLFieldConfig<any, any>;
+}
+
+/**
+ * Given a function to map from an ID to an underlying object, and a function
+ * to map from an underlying object to the concrete GraphQLObjectType it
+ * corresponds to, constructs a `Node` interface that objects can implement,
+ * and a field config for a `node` root field.
+ *
+ * If the typeResolver is omitted, object resolution on the interface will be
+ * handled with the `isTypeOf` method on object types, as with any GraphQL
+ * interface without a provided `resolveType` method.
+ */
+export function nodeDefinitions<TContext>(
+  idFetcher: (id: string, context: TContext, info: GraphQLResolveInfo) => any,
+  typeResolver?: GraphQLTypeResolver<any, TContext>,
+): GraphQLNodeDefinitions;
+
+export interface ResolvedGlobalId {
+  type: string;
+  id: string;
+}
+
+/**
+ * Takes a type name and an ID specific to that type name, and returns a
+ * "global ID" that is unique among all types.
+ */
+export function toGlobalId(type: string, id: string): string;
+
+/**
+ * Takes the "global ID" created by toGlobalID, and returns the type name and ID
+ * used to create it.
+ */
+export function fromGlobalId(globalId: string): ResolvedGlobalId;
+
+/**
+ * Creates the configuration for an id field on a node, using `toGlobalId` to
+ * construct the ID from the provided typename. The type-specific ID is fetched
+ * by calling idFetcher on the object, or if not provided, by accessing the `id`
+ * property on the object.
+ */
+export function globalIdField(
+  typeName?: string,
+  idFetcher?: (object: any, context: any, info: GraphQLResolveInfo) => string,
+): GraphQLFieldConfig<any, any>;

--- a/src/node/plural.d.ts
+++ b/src/node/plural.d.ts
@@ -1,0 +1,18 @@
+import type {
+  GraphQLFieldConfig,
+  GraphQLInputType,
+  GraphQLOutputType,
+  GraphQLResolveInfo,
+} from 'graphql';
+
+export interface PluralIdentifyingRootFieldConfig {
+  argName: string;
+  inputType: GraphQLInputType;
+  outputType: GraphQLOutputType;
+  resolveSingleInput(input: any, context: any, info: GraphQLResolveInfo): any;
+  description?: string;
+}
+
+export function pluralIdentifyingRootField(
+  config: PluralIdentifyingRootFieldConfig,
+): GraphQLFieldConfig<any, any>;


### PR DESCRIPTION
The DefinitelyTyped definitions are pretty misaligned with the Flow definitions. A good example is `ConnectionConfig.nodeType` which is typed as GraphQLObjectType in Flow (here) but is effectively typed as GraphQLOutputType in DT ([here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/graphql-relay/index.d.ts#L70)). I'll do a separate PR to sync these with Flow so that there's a clear record of what changed. The only thing I did sync was the comments to reduce the diff for the next PR.