### PR TITLE
Fix npm install via git

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint": "eslint .",
     "check": "flow check",
     "check:spelling": "cspell '**/*'",
-    "build": "node resources/build.js"
+    "build": "node resources/build.js",
+    "prepare": "npm run build && cp ./npmDist/* ./"
   },
   "peerDependencies": {
     "graphql": "^14.7.0 || ^15.5.0"


### PR DESCRIPTION
The current package.json fails to build the package when installing from git via npm. This commit just adds a prepare script that will build the package and copy the build files to the package root.

Signed-off-by: Layne Bernardo <LMBernar@uark.edu>