### PR TITLE
tests: replaces introspection queries with printing schemas

### DIFF
--- a/src/__testUtils__/__tests__/dedent-test.js
+++ b/src/__testUtils__/__tests__/dedent-test.js
@@ -1,0 +1,131 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { dedent, dedentString } from '../dedent';
+
+describe('dedentString', () => {
+  it('removes indentation in typical usage', () => {
+    const output = dedentString(`
+      type Query {
+        me: User
+      }
+
+      type User {
+        id: ID
+        name: String
+      }
+    `);
+    expect(output).to.equal(
+      [
+        'type Query {',
+        '  me: User',
+        '}',
+        '',
+        'type User {',
+        '  id: ID',
+        '  name: String',
+        '}',
+      ].join('\n'),
+    );
+  });
+
+  it('removes only the first level of indentation', () => {
+    const output = dedentString(`
+            first
+              second
+                third
+                  fourth
+    `);
+    expect(output).to.equal(
+      ['first', '  second', '    third', '      fourth'].join('\n'),
+    );
+  });
+
+  it('does not escape special characters', () => {
+    const output = dedentString(`
+      type Root {
+        field(arg: String = "wi\th de\fault"): String
+      }
+    `);
+    expect(output).to.equal(
+      [
+        'type Root {',
+        '  field(arg: String = "wi\th de\fault"): String',
+        '}',
+      ].join('\n'),
+    );
+  });
+
+  it('also removes indentation using tabs', () => {
+    const output = dedentString(`
+        \t\t    type Query {
+        \t\t      me: User
+        \t\t    }
+    `);
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
+  });
+
+  it('removes leading and trailing newlines', () => {
+    const output = dedentString(`
+
+
+      type Query {
+        me: User
+      }
+
+
+    `);
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
+  });
+
+  it('removes all trailing spaces and tabs', () => {
+    const output = dedentString(`
+      type Query {
+        me: User
+      }
+          \t\t  \t `);
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
+  });
+
+  it('works on text without leading newline', () => {
+    const output = dedentString(`      type Query {
+        me: User
+      }
+    `);
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
+  });
+});
+
+describe('dedent', () => {
+  it('removes indentation in typical usage', () => {
+    const output = dedent`
+      type Query {
+        me: User
+      }
+    `;
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
+  });
+
+  it('supports expression interpolation', () => {
+    const name = 'John';
+    const surname = 'Doe';
+    const output = dedent`
+      {
+        "me": {
+          "name": "${name}",
+          "surname": "${surname}"
+        }
+      }
+    `;
+    expect(output).to.equal(
+      [
+        '{',
+        '  "me": {',
+        '    "name": "John",',
+        '    "surname": "Doe"',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+  });
+});

--- a/src/__testUtils__/dedent.js
+++ b/src/__testUtils__/dedent.js
@@ -1,0 +1,39 @@
+export function dedentString(string: string): string {
+  const trimmedStr = string
+    .replace(/^\n*/m, '') //  remove leading newline
+    .replace(/[ \t\n]*$/, ''); // remove trailing spaces and tabs
+
+  // fixes indentation by removing leading spaces and tabs from each line
+  let indent = '';
+  for (const char of trimmedStr) {
+    if (char !== ' ' && char !== '\t') {
+      break;
+    }
+    indent += char;
+  }
+
+  return trimmedStr.replace(RegExp('^' + indent, 'mg'), ''); // remove indent
+}
+
+/**
+ * An ES6 string tag that fixes indentation and also trims string.
+ *
+ * Example usage:
+ * const str = dedent`
+ *   {
+ *     test
+ *   }
+ * `;
+ * str === "{\n  test\n}";
+ */
+export function dedent(
+  strings: $ReadOnlyArray<string>,
+  ...values: $ReadOnlyArray<string>
+): string {
+  let str = strings[0];
+
+  for (let i = 1; i < strings.length; ++i) {
+    str += values[i - 1] + strings[i]; // interpolation
+  }
+  return dedentString(str);
+}

--- a/src/node/__tests__/plural-test.js
+++ b/src/node/__tests__/plural-test.js
@@ -6,7 +6,10 @@ import {
   GraphQLSchema,
   GraphQLString,
   graphqlSync,
+  printSchema,
 } from 'graphql';
+
+import { dedent } from '../../__testUtils__/dedent';
 
 import { pluralIdentifyingRootField } from '../plural';
 
@@ -74,79 +77,18 @@ describe('pluralIdentifyingRootField()', () => {
     });
   });
 
-  it('correctly introspects', () => {
-    const source = `
-      {
-        __schema {
-          queryType {
-            fields {
-              name
-              args {
-                name
-                type {
-                  kind
-                  ofType {
-                    kind
-                    ofType {
-                      kind
-                      ofType {
-                        name
-                        kind
-                      }
-                    }
-                  }
-                }
-              }
-              type {
-                kind
-                ofType {
-                  name
-                  kind
-                }
-              }
-            }
-          }
-        }
+  it('generates correct types', () => {
+    // FIXME remove trimEnd after we update to `graphql@16.0.0`
+    expect(printSchema(schema).trimEnd()).to.deep.equal(dedent`
+      type Query {
+        """Map from a username to the user"""
+        usernames(usernames: [String!]!): [User]
       }
-    `;
 
-    expect(graphqlSync({ schema, source })).to.deep.equal({
-      data: {
-        __schema: {
-          queryType: {
-            fields: [
-              {
-                name: 'usernames',
-                args: [
-                  {
-                    name: 'usernames',
-                    type: {
-                      kind: 'NON_NULL',
-                      ofType: {
-                        kind: 'LIST',
-                        ofType: {
-                          kind: 'NON_NULL',
-                          ofType: {
-                            name: 'String',
-                            kind: 'SCALAR',
-                          },
-                        },
-                      },
-                    },
-                  },
-                ],
-                type: {
-                  kind: 'LIST',
-                  ofType: {
-                    name: 'User',
-                    kind: 'OBJECT',
-                  },
-                },
-              },
-            ],
-          },
-        },
-      },
-    });
+      type User {
+        username: String
+        url: String
+      }
+    `);
   });
 });


### PR DESCRIPTION
Reuse `dedent` from `graphql-js`