### PR TITLE
feat: remove typescript only interface export

### DIFF
--- a/src/connection/arrayConnection.d.ts
+++ b/src/connection/arrayConnection.d.ts
@@ -4,8 +4,7 @@ import type {
   ConnectionCursor,
 } from './connection';
 
-// TS_SPECIFIC: This type is only exported by TypeScript
-export interface ArraySliceMetaInfo {
+interface ArraySliceMetaInfo {
   sliceStart: number;
   arrayLength: number;
 }

--- a/src/connection/connection.d.ts
+++ b/src/connection/connection.d.ts
@@ -9,8 +9,7 @@ import type {
   Thunk,
 } from 'graphql';
 
-// TS_SPECIFIC: This type is only exported by TypeScript. Flow uses the spread operator instead.
-export interface ForwardConnectionArgs {
+interface ForwardConnectionArgs {
   after: { type: GraphQLScalarType };
   first: { type: GraphQLScalarType };
 }
@@ -22,8 +21,7 @@ export interface ForwardConnectionArgs {
 export const forwardConnectionArgs: GraphQLFieldConfigArgumentMap &
   ForwardConnectionArgs;
 
-// TS_SPECIFIC: This type is only exported by TypeScript. Flow uses the spread operator instead.
-export interface BackwardConnectionArgs {
+interface BackwardConnectionArgs {
   before: { type: GraphQLScalarType };
   last: { type: GraphQLScalarType };
 }

--- a/src/mutation/mutation.d.ts
+++ b/src/mutation/mutation.d.ts
@@ -7,14 +7,8 @@ import type {
   Thunk,
 } from 'graphql';
 
-// TS_SPECIFIC: This type is only exported by TypeScript
-export type MutationFn = (
-  object: any,
-  ctx: any,
-  info: GraphQLResolveInfo,
-) => unknown;
+type MutationFn = (object: any, ctx: any, info: GraphQLResolveInfo) => unknown;
 
-// TS_SPECIFIC: This type is only exported by TypeScript
 /**
  * A description of a mutation consumable by mutationWithClientMutationId
  * to create a GraphQLFieldConfig for that mutation.
@@ -29,7 +23,7 @@ export type MutationFn = (
  * input field, and it should return an Object with a key for each
  * output field. It may return synchronously, or return a Promise.
  */
-export interface MutationConfig {
+interface MutationConfig {
   name: string;
   description?: string;
   deprecationReason?: string;

--- a/src/node/node.d.ts
+++ b/src/node/node.d.ts
@@ -5,8 +5,7 @@ import type {
   GraphQLTypeResolver,
 } from 'graphql';
 
-// TS_SPECIFIC: This type is only exported by TypeScript
-export interface GraphQLNodeDefinitions<TContext> {
+interface GraphQLNodeDefinitions<TContext> {
   nodeInterface: GraphQLInterfaceType;
   nodeField: GraphQLFieldConfig<any, TContext>;
   nodesField: GraphQLFieldConfig<any, TContext>;
@@ -31,8 +30,7 @@ export function nodeDefinitions<TContext>(
   typeResolver?: GraphQLTypeResolver<any, TContext>,
 ): GraphQLNodeDefinitions<TContext>;
 
-// TS_SPECIFIC: This type is only exported by TypeScript
-export interface ResolvedGlobalId {
+interface ResolvedGlobalId {
   type: string;
   id: string;
 }

--- a/src/node/plural.d.ts
+++ b/src/node/plural.d.ts
@@ -5,8 +5,7 @@ import type {
   GraphQLResolveInfo,
 } from 'graphql';
 
-// TS_SPECIFIC: This type is only exported by TypeScript
-export interface PluralIdentifyingRootFieldConfig {
+interface PluralIdentifyingRootFieldConfig {
   argName: string;
   inputType: GraphQLInputType;
   outputType: GraphQLOutputType;


### PR DESCRIPTION
This is a breaking change. There isn't any history on the files we we export these if users have any issues we can revert this change. 

From #340 36c8ad7a5c1c7c83a1d57d4dfb82ba211d697147