### PR TITLE
Fix hasPreviousPage/hasNextPage logic for array connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-relay",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "A library to help construct a graphql-js server supporting react-relay.",
   "license": "MIT",
   "private": true,

--- a/src/connection/__tests__/arrayConnection-test.ts
+++ b/src/connection/__tests__/arrayConnection-test.ts
@@ -1,13 +1,13 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import { describe, it } from 'mocha';
 
 import {
-  offsetToCursor,
-  connectionFromArray,
-  connectionFromArraySlice,
-  connectionFromPromisedArray,
-  connectionFromPromisedArraySlice,
-  cursorForObjectInConnection,
+    connectionFromArray,
+    connectionFromArraySlice,
+    connectionFromPromisedArray,
+    connectionFromPromisedArraySlice,
+    cursorForObjectInConnection,
+    offsetToCursor,
 } from '../arrayConnection';
 
 const arrayABCDE = ['A', 'B', 'C', 'D', 'E'];
@@ -103,7 +103,7 @@ describe('connectionFromArray()', () => {
         pageInfo: {
           startCursor: cursorC,
           endCursor: cursorD,
-          hasPreviousPage: false,
+          hasPreviousPage: true,
           hasNextPage: true,
         },
       });
@@ -119,7 +119,7 @@ describe('connectionFromArray()', () => {
         pageInfo: {
           startCursor: cursorC,
           endCursor: cursorE,
-          hasPreviousPage: false,
+          hasPreviousPage: true,
           hasNextPage: false,
         },
       });
@@ -136,7 +136,7 @@ describe('connectionFromArray()', () => {
           startCursor: cursorB,
           endCursor: cursorC,
           hasPreviousPage: true,
-          hasNextPage: false,
+          hasNextPage: true,
         },
       });
     });
@@ -152,7 +152,7 @@ describe('connectionFromArray()', () => {
           startCursor: cursorA,
           endCursor: cursorC,
           hasPreviousPage: false,
-          hasNextPage: false,
+          hasNextPage: true,
         },
       });
     });
@@ -168,7 +168,7 @@ describe('connectionFromArray()', () => {
         pageInfo: {
           startCursor: cursorB,
           endCursor: cursorC,
-          hasPreviousPage: false,
+          hasPreviousPage: true,
           hasNextPage: true,
         },
       });
@@ -185,7 +185,7 @@ describe('connectionFromArray()', () => {
         pageInfo: {
           startCursor: cursorB,
           endCursor: cursorD,
-          hasPreviousPage: false,
+          hasPreviousPage: true,
           hasNextPage: false,
         },
       });
@@ -202,7 +202,7 @@ describe('connectionFromArray()', () => {
         pageInfo: {
           startCursor: cursorB,
           endCursor: cursorD,
-          hasPreviousPage: false,
+          hasPreviousPage: true,
           hasNextPage: false,
         },
       });
@@ -220,7 +220,7 @@ describe('connectionFromArray()', () => {
           startCursor: cursorC,
           endCursor: cursorD,
           hasPreviousPage: true,
-          hasNextPage: false,
+          hasNextPage: true,
         },
       });
     });
@@ -237,7 +237,7 @@ describe('connectionFromArray()', () => {
           startCursor: cursorB,
           endCursor: cursorD,
           hasPreviousPage: false,
-          hasNextPage: false,
+          hasNextPage: true,
         },
       });
     });
@@ -254,7 +254,7 @@ describe('connectionFromArray()', () => {
           startCursor: cursorB,
           endCursor: cursorD,
           hasPreviousPage: false,
-          hasNextPage: false,
+          hasNextPage: true,
         },
       });
     });
@@ -308,6 +308,8 @@ describe('connectionFromArray()', () => {
         },
       };
 
+      // before/after cursors out of range: offsets are outside [0, arrayLength)
+      // so neither hasPreviousPage nor hasNextPage is triggered
       expect(
         connectionFromArray(arrayABCDE, { before: offsetToCursor(6) }),
       ).to.deep.equal(allEdges);
@@ -333,8 +335,8 @@ describe('connectionFromArray()', () => {
         pageInfo: {
           startCursor: null,
           endCursor: null,
-          hasPreviousPage: false,
-          hasNextPage: false,
+          hasPreviousPage: true,
+          hasNextPage: true,
         },
       });
     });
@@ -404,7 +406,7 @@ describe('connectionFromArraySlice()', () => {
       pageInfo: {
         startCursor: cursorB,
         endCursor: cursorC,
-        hasPreviousPage: false,
+        hasPreviousPage: true,
         hasNextPage: true,
       },
     });
@@ -427,7 +429,7 @@ describe('connectionFromArraySlice()', () => {
       pageInfo: {
         startCursor: cursorB,
         endCursor: cursorC,
-        hasPreviousPage: false,
+        hasPreviousPage: true,
         hasNextPage: true,
       },
     });
@@ -450,7 +452,7 @@ describe('connectionFromArraySlice()', () => {
       pageInfo: {
         startCursor: cursorC,
         endCursor: cursorC,
-        hasPreviousPage: false,
+        hasPreviousPage: true,
         hasNextPage: true,
       },
     });
@@ -473,7 +475,7 @@ describe('connectionFromArraySlice()', () => {
       pageInfo: {
         startCursor: cursorC,
         endCursor: cursorC,
-        hasPreviousPage: false,
+        hasPreviousPage: true,
         hasNextPage: true,
       },
     });
@@ -496,7 +498,7 @@ describe('connectionFromArraySlice()', () => {
       pageInfo: {
         startCursor: cursorD,
         endCursor: cursorE,
-        hasPreviousPage: false,
+        hasPreviousPage: true,
         hasNextPage: false,
       },
     });
@@ -519,7 +521,7 @@ describe('connectionFromArraySlice()', () => {
       pageInfo: {
         startCursor: cursorC,
         endCursor: cursorD,
-        hasPreviousPage: false,
+        hasPreviousPage: true,
         hasNextPage: true,
       },
     });
@@ -542,7 +544,7 @@ describe('connectionFromArraySlice()', () => {
       pageInfo: {
         startCursor: cursorD,
         endCursor: cursorD,
-        hasPreviousPage: false,
+        hasPreviousPage: true,
         hasNextPage: true,
       },
     });

--- a/src/connection/arrayConnection.ts
+++ b/src/connection/arrayConnection.ts
@@ -1,9 +1,9 @@
 import { base64, unbase64 } from '../utils/base64';
 
 import type {
-  Connection,
-  ConnectionArguments,
-  ConnectionCursor,
+    Connection,
+    ConnectionArguments,
+    ConnectionCursor,
 } from './connection';
 
 interface ArraySliceMetaInfo {
@@ -96,16 +96,49 @@ export function connectionFromArraySlice<T>(
 
   const firstEdge = edges[0];
   const lastEdge = edges[edges.length - 1];
-  const lowerBound = after != null ? afterOffset + 1 : 0;
-  const upperBound = before != null ? beforeOffset : arrayLength;
+
+  // Spec: https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
+  //
+  // HasPreviousPage:
+  //   - If `last` is set: true if edges before the window were trimmed by `last`
+  //   - If `after` is set: true if elements exist prior to `after` (we can determine this efficiently)
+  //   - Otherwise: false
+  //
+  // HasNextPage:
+  //   - If `first` is set: true if edges after the window were trimmed by `first`
+  //   - If `before` is set: true if elements exist following `before` (we can determine this efficiently)
+  //   - Otherwise: false
+  let hasPreviousPage: boolean;
+  if (typeof last === 'number') {
+    // Did `last` trim edges from the front of the after/before window?
+    const lowerBound = after != null ? afterOffset + 1 : 0;
+    hasPreviousPage = startOffset > lowerBound;
+  } else if (after != null) {
+    // Elements exist prior to `after` if afterOffset is a valid position in the array
+    hasPreviousPage = afterOffset >= 0 && afterOffset < arrayLength;
+  } else {
+    hasPreviousPage = false;
+  }
+
+  let hasNextPage: boolean;
+  if (typeof first === 'number') {
+    // Did `first` trim edges from the end of the after/before window?
+    const upperBound = before != null ? beforeOffset : arrayLength;
+    hasNextPage = endOffset < upperBound;
+  } else if (before != null) {
+    // Elements exist following `before` if beforeOffset is a valid position in the array
+    hasNextPage = beforeOffset >= 0 && beforeOffset < arrayLength;
+  } else {
+    hasNextPage = false;
+  }
+
   return {
     edges,
     pageInfo: {
       startCursor: firstEdge ? firstEdge.cursor : null,
       endCursor: lastEdge ? lastEdge.cursor : null,
-      hasPreviousPage:
-        typeof last === 'number' ? startOffset > lowerBound : false,
-      hasNextPage: typeof first === 'number' ? endOffset < upperBound : false,
+      hasPreviousPage,
+      hasNextPage,
     },
   };
 }


### PR DESCRIPTION
Update connectionFromArraySlice to follow Relay spec for hasPreviousPage and hasNextPage.

This makes the PageInfo return `hasPreviousPage` and `hasNextPage` regardless of the direction of pagination (`first` with `after` or `last` with `before`)